### PR TITLE
feat: ChatModel과 ChatClient를 이용한 AI 연동

### DIFF
--- a/spring-ai/src/main/java/com/gani/springai/presentation/AiController.java
+++ b/spring-ai/src/main/java/com/gani/springai/presentation/AiController.java
@@ -1,23 +1,38 @@
 package com.gani.springai.presentation;
 
+import com.gani.springai.service.ChatModelByClient;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
 
+@RequiredArgsConstructor
 @RestController
 @RequestMapping("/ai")
 @Slf4j
 public class AiController {
+//    private final ChatModelService chatModelService;
+    private final ChatModelByClient chatModelService;
 
     @PostMapping(
-            value = "/chat",
+            value = "/chat-model",
             consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE,
             produces = MediaType.TEXT_PLAIN_VALUE)
     public String chat(@RequestParam("question") String question) {
-        return "아직 모델과 연결되지 않았습니다.";
+        return chatModelService.generateText(question);
+    }
+
+    @PostMapping(
+            value = "/chat-model-stream",
+            consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE,
+            produces = MediaType.APPLICATION_NDJSON_VALUE
+    )
+    public Flux<String> chatStream(@RequestParam("question") String question) {
+        return chatModelService.generateStreamText(question);
     }
 
 }

--- a/spring-ai/src/main/java/com/gani/springai/presentation/HomeController.java
+++ b/spring-ai/src/main/java/com/gani/springai/presentation/HomeController.java
@@ -11,4 +11,14 @@ public class HomeController {
         return "home";
     }
 
+    @GetMapping("/chat")
+    public String chatModel() {
+        return "chat-model/chat-model";
+    }
+
+    @GetMapping("/chat-stream")
+    public String chatModelStream() {
+        return "chat-model/chat-model-stream";
+    }
+
 }

--- a/spring-ai/src/main/java/com/gani/springai/service/ChatModelByClient.java
+++ b/spring-ai/src/main/java/com/gani/springai/service/ChatModelByClient.java
@@ -1,0 +1,48 @@
+package com.gani.springai.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+@Service
+@Slf4j
+public class ChatModelByClient {
+    private ChatClient chatClient;
+
+    public ChatModelByClient(ChatClient.Builder chatClientBuilder) {
+        this.chatClient = chatClientBuilder.build();
+    }
+
+    public String generateText(String question) {
+        String answer = chatClient.prompt()
+                .system("사용자 질문에 대해 한국어로 답변을 해야 합니다.")
+                .user(question)
+                .options(ChatOptions.builder()
+                        .temperature(0.3)
+                        .maxTokens(1000)
+                        .build()
+                )
+                .call()
+                .content();
+
+        return answer;
+    }
+
+    public Flux<String> generateStreamText(String question) {
+        Flux<String> fluxString = chatClient.prompt()
+                .system("사용자 질문에 대해 한국어로 답변을 해야 합니다.")
+                .user(question)
+                .options(ChatOptions.builder()
+                        .temperature(0.3)
+                        .maxTokens(1000)
+                        .build()
+                )
+                .stream()
+                .content();
+
+        return fluxString;
+    }
+
+}

--- a/spring-ai/src/main/java/com/gani/springai/service/ChatModelService.java
+++ b/spring-ai/src/main/java/com/gani/springai/service/ChatModelService.java
@@ -1,0 +1,77 @@
+package com.gani.springai.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.messages.AssistantMessage;
+import org.springframework.ai.chat.messages.SystemMessage;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+public class ChatModelService {
+    private final ChatModel chatModel;
+
+    public String generateText(String question) {
+        SystemMessage systemMessage = SystemMessage.builder()
+                .text("사용자의 질문에 대해 한국어로 답변해야 합니다. 불필요한 수식어는 최대한 배제합니다.")
+                .build();
+
+        UserMessage userMessage = UserMessage.builder()
+                .text(question)
+                .build();
+
+        ChatOptions chatOptions = ChatOptions.builder()
+                .model("gpt-4o-mini")
+                .temperature(0.3)
+                .maxTokens(1000)
+                .build();
+
+        Prompt prompt = Prompt.builder()
+                .messages(systemMessage, userMessage)
+                .chatOptions(chatOptions)
+                .build();
+
+        ChatResponse chatResponse = chatModel.call(prompt);
+        AssistantMessage assistantMessage = chatResponse.getResult().getOutput();
+        String answer = assistantMessage.getText();
+
+        return answer;
+    }
+
+    public Flux<String> generateStreamText(String question) {
+        SystemMessage systemMessage = SystemMessage.builder()
+                .text("사용자의 질문에 대해 한국어로 답변해야 합니다. 불필요한 수식어는 최대한 배제합니다.")
+                .build();
+
+        UserMessage userMessage = UserMessage.builder()
+                .text(question)
+                .build();
+
+        ChatOptions chatOptions = ChatOptions.builder()
+                .model("gpt-4o-mini")
+                .temperature(0.3)
+                .maxTokens(1000)
+                .build();
+
+        Prompt prompt = Prompt.builder()
+                .messages(systemMessage, userMessage)
+                .chatOptions(chatOptions)
+                .build();
+
+        Flux<ChatResponse> fluxResponse = chatModel.stream(prompt);
+
+        return fluxResponse.map(chatResponse -> {
+            AssistantMessage assistantMessage = chatResponse.getResult().getOutput();
+            String chunk = assistantMessage.getText();
+            if (chunk == null) chunk = "";
+            return chunk;
+        });
+    }
+}

--- a/spring-ai/src/main/resources/templates/chat-model/chat-model-stream.html
+++ b/spring-ai/src/main/resources/templates/chat-model/chat-model-stream.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spring AI</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js"></script>
+  <link href="/css/springai.css" rel="stylesheet" />
+  <script src="/js/springai.js"></script>
+  <script>
+    // ##### 제출 버튼을 클릭했을 때 실행하는 함수 #####
+    async function handleSubmit() {
+      try {
+        // 텍스트 질문을 얻고 대화 패널에 추가하기
+        const question = document.getElementById("question").value;
+        if (question === "") return;
+        springai.addUserQuestion(question, "chatPanel");
+
+        // 응답이 오기까지 스피너 보여주기
+        springai.setSpinner("spinner", true);
+
+        // AJAX 요청하고 응답받기
+        const response = await fetch('/ai/chat-model-stream', {
+          method: "post",
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Accept': 'application/x-ndjson' //라인으로 구분된 청크 텍스트
+          },
+          body: new URLSearchParams({ question })
+        });
+
+        // AI 모델 답변이 들어갈 위치를 대화 패널에 추가
+        const uuid = springai.addAnswerPlaceHolder("chatPanel");
+
+        // 텍스트 답변 출력하기
+        springai.printAnswerText(response.body, uuid, "chatPanel");
+      } catch (error) {
+        console.log(error)
+      } finally {
+        //스피너 숨기기
+        springai.setSpinner("spinner", false);
+      }
+    } 
+  </script>
+</head>
+
+<body>
+  <div class="d-flex flex-column vh-100">
+    <div id="headPanel" class="navbar justify-content-between">
+      <a href="/" class="navbar-brand ps-2">
+        <img src="/image/spring_ai_logo_with_text.svg" width="200" />
+      </a>
+      <div id="spinner" class="spinner-border text-success d-none me-3" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+    </div>
+
+    <div id="chatPanel" class="flex-grow-1 container-fluid h-100 my-2" style="overflow-y:auto; overflow-x:hidden;">
+      <div class="d-flex justify-content-start border-bottom m-2">
+        <table>
+          <tr>
+            <td><img src="/image/assistant.png" width="50" /></td>
+            <td><span>질문을 올려주세요.</span></td>
+          </tr>
+        </table>
+      </div>
+    </div>
+
+    <div id="inputPanel" class="bg-secondary-subtle">
+      <div class="input-group p-2">
+        <span class="input-group-text">질문</span>
+        <textarea id="question" class="form-control">Spring AI에 대해 300자 이내로 설명해줘</textarea>
+        <span class="input-group-text">
+          <button type="button" class="btn btn-primary" onclick="handleSubmit()">제출</button>
+        </span>
+      </div>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/spring-ai/src/main/resources/templates/chat-model/chat-model.html
+++ b/spring-ai/src/main/resources/templates/chat-model/chat-model.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spring AI</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js"></script>
+  <link href="/css/springai.css" rel="stylesheet" />
+  <script src="/js/springai.js"></script>
+  <script>
+    // ##### 제출 버튼을 클릭했을 때 실행하는 함수 #####
+    async function handleSubmit() {
+      try {
+        // 텍스트 질문을 얻고 대화 패널에 추가하기
+        const question = document.getElementById("question").value;
+        if (question === "") return;
+        springai.addUserQuestion(question, "chatPanel");
+
+        // 응답이 오기까지 스피너 보여주기
+        springai.setSpinner("spinner", true);
+
+				// AJAX 요청하고 응답받기
+				const response = await fetch('/ai/chat-model', {
+				  method: "post",
+					headers: {
+					  'Content-Type': 'application/x-www-form-urlencoded',
+					  'Accept': 'text/plain'
+					},					
+				  body: new URLSearchParams({ question })
+				});
+
+        // AI 모델 답변이 들어갈 위치를 대화 패널에 추가
+        const uuid = springai.addAnswerPlaceHolder("chatPanel");
+        
+        // 텍스트 답변 출력하기
+        springai.printAnswerText(response.body, uuid, "chatPanel");
+      } catch (error) {
+        console.log(error)
+      } finally {
+        //스피너 숨기기
+        springai.setSpinner("spinner", false);
+      }
+    } 
+  </script>
+</head>
+
+<body>
+  <div class="d-flex flex-column vh-100">
+    <div id="headPanel" class="navbar justify-content-between">
+      <a href="/" class="navbar-brand ps-2">
+        <img src="/image/spring_ai_logo_with_text.svg" width="200" />
+      </a>
+      <div id="spinner" class="spinner-border text-success d-none me-3" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+    </div>
+
+    <div id="chatPanel" class="flex-grow-1 container-fluid h-100 my-2" style="overflow-y:auto; overflow-x:hidden;">
+      <div class="d-flex justify-content-start border-bottom m-2">
+        <table>
+          <tr>
+            <td><img src="/image/assistant.png" width="50" /></td>
+            <td><span>질문을 올려주세요.</span></td>
+          </tr>
+        </table>
+      </div>
+    </div>
+
+    <div id="inputPanel" class="bg-secondary-subtle">
+      <div class="input-group p-2">
+        <span class="input-group-text">질문</span>
+        <textarea id="question" class="form-control">Spring AI에 대해 100자 이내로 설명해줘</textarea>
+        <span class="input-group-text">
+          <button type="button" class="btn btn-primary" onclick="handleSubmit()">제출</button>
+        </span>
+      </div>
+    </div>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added chat experience with two pages: /chat (standard) and /chat-stream (live streaming).
  - Introduced AI chat endpoints: /ai/chat-model (text response) and /ai/chat-model-stream (NDJSON streaming) for faster, incremental answers.
  - UI enhancements include spinner feedback, chat history panels, and prefilled example prompts (Korean).

- Refactor
  - Updated chat API path from /ai/chat to /ai/chat-model to align with new capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->